### PR TITLE
Fixed issues with streamer pipeline for local files

### DIFF
--- a/streamer.sh
+++ b/streamer.sh
@@ -2,22 +2,21 @@
 # * Video output directory
 # * youtube streaming key
 VIDEO_OUTPUT=$HOME/Videos/video%05d.mp4
+AUDIO_DEVICE=hw:4,0
 
 # wait for desktop to settle
 sleep 0
 
-gst-launch-1.0 -v -e ximagesrc use-damage=0 \
-  ! video/x-raw,framerate=30/1 \
-  ! queue \
-  ! videoconvert \
-  ! videorate \
-  ! queue \
-  ! vaapih264enc \
-  ! h264parse \
-  ! mux. alsasrc device=hw:3,0 \
-  ! queue \
-  ! audioconvert \
-  ! voaacenc \
-  ! mux. mp4mux name=mux \
-  ! filesink location=$VIDEO_OUTPUT
-
+gst-launch-1.0 -e splitmuxsink name=mux location=$VIDEO_OUTPUT max-size-bytes=2147483648 \
+        ximagesrc use-damage=0 \
+        ! 'video/x-raw,framerate=30/1' \
+        ! queue \
+        ! videoconvert \
+        ! vaapih264enc \
+        ! h264parse \
+        ! mux.video \
+        alsasrc device=$AUDIO_DEVICE \
+        ! queue \
+        ! audioconvert \
+        ! voaacenc \
+        ! mux.audio_0


### PR DESCRIPTION
Switched to splitmuxsink which allows rotating files based on size (or time), set the file size to 2GB. 

I also made the audio source a variable for the moment, if we had a specific audio device then we could use `arecord -l` to determine the appropriate device number before launching the pipeline.

This really needs to switch to a python script that uses the Gstreamer python extensions to setup the pipeline.  By doing that we would be able to put the timestamp in the filename which would cause subsequent runs not to overwrite previous files.