### PR TITLE
Update to use `video-streamer` app and more politely kill the process

### DIFF
--- a/racecapture_streaming_install.sh
+++ b/racecapture_streaming_install.sh
@@ -45,10 +45,10 @@ set startupmessage 0
 ## Force the cursor to the lower right when RC starts up
 addhook newwindow banish
 ## Kill gst-launch politely so the file will close properly
-addhook quit exec killall -w -s SIGINT gst-launch-1.0
+#addhook quit exec killall -w -s SIGINT gst-launch-1.0
 
 ## Make it so that 'ctrl-t q' quits
-bind q quit
+bind q exec bash -c "killall -w -s SIGINT video-streamer && ratpoison -c quit"
 
 ## Set the cursor to the left pointer
 exec xsetroot -cursor_name left_ptr
@@ -65,7 +65,7 @@ exec xset -dpms
 exec /bin/bash -c 'cd ~/racecapture && LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./race_capture >> ~/racecapture.log 2>&1'
 
 ## Start the video capture/streaming
-exec $HOME/streamer/streamer.sh >> ~/streamer.log 2>&1
+exec $HOME/video-streamer/video-streamer >> ~/streamer.log 2>&1
 EOF
 
 echo "Changing your window manager to single app mode"


### PR DESCRIPTION
This binds ctrl+t q to run killall followed by using ratpoison to send in the quit command.  I don't think the hook waits for the command to complete before quiting.